### PR TITLE
Fix moving average inefficiency

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const audio = document.getElementById('audio');
   const container = document.getElementById('visualizer');
   const playPauseButton = document.getElementById('play-pause-button');
+  const currentMeasureDisplay = document.getElementById('current-measure');
 
   const playIconSVG = `<svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"></path></svg>`;
   const pauseIconSVG = `<svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 011-1h4a1 1 0 110 2H8a1 1 0 01-1-1zm1 4a1 1 0 100 2h4a1 1 0 100-2H8z" clip-rule="evenodd"></path></svg>`;
@@ -342,7 +343,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             // Update display during drag
-            const currentMeasureDisplay = document.getElementById('current-measure');
             if (currentMeasureDisplay) {
               currentMeasureDisplay.textContent = lastDraggedMeasure.toFixed(1);
             }
@@ -361,7 +361,6 @@ document.addEventListener('DOMContentLoaded', () => {
              }
 
             // Update the display with final value
-            const currentMeasureDisplay = document.getElementById('current-measure');
             if (currentMeasureDisplay) {
                 currentMeasureDisplay.textContent = lastDraggedMeasure.toFixed(1);
             }
@@ -540,7 +539,6 @@ document.addEventListener('DOMContentLoaded', () => {
            overviewMarker.attr('x1', clampedOverviewPosX).attr('x2', clampedOverviewPosX);
       }
 
-      const currentMeasureDisplay = document.getElementById('current-measure');
       if (currentMeasureDisplay) {
         currentMeasureDisplay.textContent = currentMeasure.toFixed(1);
       }
@@ -566,7 +564,6 @@ document.addEventListener('DOMContentLoaded', () => {
           overviewMarker.attr('x1', clampedOverviewPosX).attr('x2', clampedOverviewPosX);
         }
 
-        const currentMeasureDisplay = document.getElementById('current-measure');
         if (currentMeasureDisplay) {
             currentMeasureDisplay.textContent = currentMeasure.toFixed(1);
         }

--- a/app.js
+++ b/app.js
@@ -225,13 +225,25 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log(`Calculating centered moving average with window size: ${windowSizeMeasures}, halfWindow: ${halfWindow}`);
     const paddedInstantaneousEnergy = Array(halfWindow).fill(0).concat(instantaneousEnergy);
     const paddedSmoothedEnergy = [];
+    let runningSum = 0;
+    let currentStart = 0;
+    let currentEnd = -1;
+    let currentCount = 0;
     for (let i = 0; i < paddedInstantaneousEnergy.length; i++) {
-        const windowStart = Math.max(0, i - halfWindow);
-        const windowEnd = Math.min(paddedInstantaneousEnergy.length, i + halfWindow + 1);
-        const windowData = paddedInstantaneousEnergy.slice(windowStart, windowEnd);
-        const sum = windowData.reduce((acc, val) => acc + val, 0);
-        const average = windowData.length > 0 ? sum / windowData.length : 0;
-        paddedSmoothedEnergy.push(average);
+        const targetStart = Math.max(0, i - halfWindow);
+        const targetEnd = Math.min(paddedInstantaneousEnergy.length - 1, i + halfWindow);
+        while (currentEnd < targetEnd) {
+            currentEnd++;
+            runningSum += paddedInstantaneousEnergy[currentEnd];
+            currentCount++;
+        }
+        while (currentStart < targetStart) {
+            runningSum -= paddedInstantaneousEnergy[currentStart];
+            currentStart++;
+            currentCount--;
+        }
+        const avg = currentCount > 0 ? runningSum / currentCount : 0;
+        paddedSmoothedEnergy.push(avg);
     }
     const smoothedEnergy = paddedSmoothedEnergy.slice(halfWindow, halfWindow + instantaneousEnergy.length);
     const maxSmoothedEnergy = d3.max(smoothedEnergy);


### PR DESCRIPTION
## Summary
- reduce moving average calculation to O(n) by tracking a running sum

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_683f40904018832e88cc8c8343e3e566