### PR TITLE
Refactor to modular JS setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,6 @@
     </aside>
     <section id="visualizer" class="flex-1 relative overflow-hidden"></section>
   </main>
-  <script src="app.js"></script>
+  <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/js/annotations.js
+++ b/js/annotations.js
@@ -1,0 +1,54 @@
+export function drawFormalAnnotations(svg, xScale, width, height, annotations) {
+  if (!svg || !xScale) return;
+
+  const annotationLayer = svg.selectAll('.formal-annotations-layer').data([null]);
+  const annotationLayerEnter = annotationLayer.enter().append('g')
+    .attr('class', 'formal-annotations-layer');
+  const annotationLayerUpdate = annotationLayerEnter.merge(annotationLayer);
+  annotationLayerUpdate.selectAll('*').remove();
+
+  const domain = xScale.domain();
+  annotations.forEach(ann => {
+    const startX = xScale(ann.start);
+    const endX = xScale(ann.end);
+    const measureX = xScale(ann.measure);
+
+    const isSectionInView = ann.type === 'section' && ann.end > domain[0] && ann.start < domain[1];
+    const isMarkerInView = ann.type === 'marker' && ann.measure >= domain[0] && ann.measure <= domain[1];
+
+    if (isSectionInView) {
+      const drawStartX = Math.max(0, startX);
+      const drawEndX = Math.min(width, endX);
+      const drawWidth = Math.max(0, drawEndX - drawStartX);
+
+      if (drawWidth > 0) {
+        annotationLayerUpdate.append('rect')
+          .attr('x', drawStartX).attr('y', -60)
+          .attr('width', drawWidth).attr('height', 20)
+          .attr('fill', ann.color).attr('opacity', 0.3);
+
+        const midMeasure = (ann.start + ann.end) / 2;
+        const midX = xScale(midMeasure);
+        if (midX >= 0 && midX <= width) {
+          annotationLayerUpdate.append('text')
+            .attr('x', midX).attr('y', -45)
+            .text(ann.label).attr('fill', ann.color)
+            .attr('font-size', 10).attr('text-anchor', 'middle')
+            .style('pointer-events', 'none');
+        }
+      }
+    } else if (isMarkerInView) {
+      if (measureX >= 0 && measureX <= width) {
+        annotationLayerUpdate.append('line')
+          .attr('x1', measureX).attr('x2', measureX)
+          .attr('y1', -60).attr('y2', height)
+          .attr('stroke', ann.color).attr('stroke-width', 1)
+          .attr('stroke-dasharray', '2,2');
+        annotationLayerUpdate.append('text')
+          .attr('x', measureX + 3).attr('y', -65).text(ann.label)
+          .attr('fill', ann.color).attr('font-size', 10)
+          .style('pointer-events', 'none');
+      }
+    }
+  });
+}

--- a/js/audioControls.js
+++ b/js/audioControls.js
@@ -1,0 +1,10 @@
+export function updatePlayPauseIcon(audio, playPauseButton, playIconSVG, pauseIconSVG) {
+  if (!audio || !playPauseButton) return;
+  if (audio.paused) {
+    playPauseButton.innerHTML = playIconSVG;
+    playPauseButton.setAttribute('aria-label', 'Play');
+  } else {
+    playPauseButton.innerHTML = pauseIconSVG;
+    playPauseButton.setAttribute('aria-label', 'Pause');
+  }
+}

--- a/js/toggles.js
+++ b/js/toggles.js
@@ -1,0 +1,33 @@
+export function setupToggles(stringsG, brassG, windsG, formalEnergyG) {
+  const toggleStrings = document.getElementById('toggle-strings');
+  const toggleBrass = document.getElementById('toggle-brass');
+  const toggleWinds = document.getElementById('toggle-winds');
+  const toggleFormal = document.getElementById('toggle-formal');
+
+  if (toggleStrings) {
+    toggleStrings.addEventListener('click', () => {
+      const isActive = toggleStrings.classList.toggle('active');
+      if (stringsG) stringsG.style('display', isActive ? 'inline' : 'none');
+    });
+  }
+  if (toggleBrass) {
+    toggleBrass.addEventListener('click', () => {
+      const isActive = toggleBrass.classList.toggle('active');
+      if (brassG) brassG.style('display', isActive ? 'inline' : 'none');
+    });
+  }
+  if (toggleWinds) {
+    toggleWinds.addEventListener('click', () => {
+      const isActive = toggleWinds.classList.toggle('active');
+      if (windsG) windsG.style('display', isActive ? 'inline' : 'none');
+    });
+  }
+  if (toggleFormal) {
+    toggleFormal.addEventListener('click', () => {
+      const isActive = toggleFormal.classList.toggle('active');
+      if (formalEnergyG) {
+        formalEnergyG.style('display', isActive ? 'inline' : 'none');
+      }
+    });
+  }
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,3 @@
+import { initVisualizer } from './js/visualizer.js';
+
+document.addEventListener('DOMContentLoaded', initVisualizer);


### PR DESCRIPTION
## Summary
- move helper functions into `js/annotations.js`, `js/audioControls.js`, and `js/toggles.js`
- import new modules from `js/visualizer.js`
- call the helpers with required parameters

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f6cdec9f0832eb80116a623e98246