### PR TITLE
Optimize brush event handling

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,23 @@
+export function throttle(fn, wait) {
+  let lastTime = 0;
+  let timeout = null;
+  return function(...args) {
+    const now = Date.now();
+    const remaining = wait - (now - lastTime);
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      lastTime = now;
+      return fn.apply(this, args);
+    }
+    if (!timeout) {
+      timeout = setTimeout(() => {
+        lastTime = Date.now();
+        timeout = null;
+        fn.apply(this, args);
+      }, remaining);
+    }
+  };
+}

--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -2,6 +2,7 @@
 import { updatePlayPauseIcon } from './audioControls.js';
 import { drawFormalAnnotations } from './annotations.js';
 import { setupToggles } from './toggles.js';
+import { throttle } from './utils.js';
 
 export function initVisualizer() {
   console.log("DOM fully loaded and parsed.");
@@ -331,7 +332,12 @@ export function initVisualizer() {
       .attr('x1', xb(1)).attr('x2', xb(1));
     console.log("Overview marker created.");
 
-    brush = d3.brushX().extent([[0, 0], [width, brushHeight]]).on('brush end', handleBrush);
+    // Throttle brush updates to reduce expensive redraws during dragging
+    const throttledHandleBrush = throttle(handleBrush, 50);
+    brush = d3.brushX()
+      .extent([[0, 0], [width, brushHeight]])
+      .on('brush', throttledHandleBrush)
+      .on('end', handleBrush);
     gBrush = overviewG.append('g')
       .attr('class', 'brush')
       .call(brush);


### PR DESCRIPTION
## Summary
- add a `throttle` utility
- throttle brush updates in visualizer to reduce redraws

## Testing
- `node --check js/visualizer.js`
- `node --check js/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_683f7845edbc832e8e31ce703bec5690